### PR TITLE
Updated RevealPlugin to support the latest Xcode

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -535,9 +535,9 @@
       },
       {
         "name": "RevealPlugin",
-        "url": "https://github.com/shjborage/Reveal-Plugin-for-XCode",
+        "url": "https://github.com/honghaoz/Reveal-Plugin-for-XCode",
         "description": "Plugin for Xcode to integrate the Reveal App to your project automatic.",
-        "screenshot": "https://github.com/shjborage/Reveal-Plugin-for-XCode/raw/master/Product-InspectWithReveal.png"
+        "screenshot": "https://github.com/honghaoz/Reveal-Plugin-for-XCode/raw/master/Product-InspectWithReveal.png"
       },
       {
         "name": "RRConstraintsPlugin",


### PR DESCRIPTION
The original repo's author seems like not maintaining his repo anymore. So I forked his repo and updated supported Xcode list

Updated file is here: https://github.com/honghaoz/Reveal-Plugin-for-Xcode/commit/777dcfefc84dde8e2310b3155b68529b2197d43d