### PR TITLE
rename Github to GitHub In Reveal-In-GitHub plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -580,8 +580,8 @@
         "screenshot": "https://github.com/shjborage/Reveal-Plugin-for-XCode/raw/master/Product-InspectWithReveal.png"
       },
       {
-        "name": "Reveal-In-Github",
-        "url": "https://github.com/lzwjava/Reveal-In-Github",
+        "name": "Reveal-In-GitHub",
+        "url": "https://github.com/lzwjava/Reveal-In-GitHub",
         "description": "Let you jump to Github History, Blame, PRs, Issues, Notifications of current repo in one second.",
         "screenshot": "https://cloud.githubusercontent.com/assets/5022872/10865607/a840173e-804b-11e5-93a4-a054743951a7.jpg"
       },


### PR DESCRIPTION
Sorry for that, some people say my spelling Github is wrong, so I change to GitHub in my project. Change `https://github.com/lzwjava/Reveal-In-Github` to `https://github.com/lzwjava/Reveal-In-GitHub`, and xcodeproj name, etc.

But installing by alcatraz will fail. Say,

> Wasn't able to find: Reveal-In-Github.xcodeproj in /**************/Library/Application Support/Alcatraz/Plug-ins/Reveal-In-Github

in [this issue](https://github.com/lzwjava/Reveal-In-GitHub/issues/4).

So I change the plugin name and url in the packages.json to fix it.

@jurre 

