### PR TITLE
add Xcode plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1966,6 +1966,12 @@
         "name": "Mantle",
         "url": "https://github.com/Ashton-W/Mantle-Xcode-Templates",
         "description": "File Templates for Models using the Mantle framework"
+      },
+      {
+        "name": "Quick Show In Finder",
+        "url": "https://github.com/lhhuai/QuickShowInFinder",
+        "description": "A Xcode Plugin to quick show in finder with using shortcut key（alt+f）.",
+        "screenshot": "https://github.com/lhhuai/QuickShowInFinder/tree/master/QuickShowInFinder/Resource/quickshowinfinder.png"
       }
     ]
   }


### PR DESCRIPTION
Quick Show In Finder

A Xcode Plugin to quick show in finder with using shortcut key（alt+f）.