### PR TITLE
Adding Phoenix

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2,6 +2,12 @@
   "packages": {
     "plugins": [
     {
+        "name": "Phoenix",
+        "url": "https://github.com/Pearapps/InitializeMe",
+        "description": "Turns a selected list of properties into a dependency injected initializer and copies it to your pasteboard. For Objective-C and Swift.",
+        "screenshot": "https://raw.githubusercontent.com/Pearapps/InitializeMe/master/Phoenix/Phoenix.png"
+    },
+    {
         "name": "StringManage",
         "url": "https://github.com/Loongwoo/StringManage",
         "description": "Manage all the strings in localizable.strings, including adding,removing,searching and checking whether it used or not.",


### PR DESCRIPTION
Adding **Phoenix** - a plugin that turns a selected list of properties into a dependency injected initializer and copies it to your pasteboard. For Objective-C and Swift.

### How it works:

1. Select your properties
2. Go to `Edit` and then click `Make Initializer And Copy` OR use the key command CMD - Shift - X.
3. Paste your initializer wherever you wish

Let me know if I set something up wrong or there are any other issues, thank you!