### PR TITLE
Adding ThinStrokes to the list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8,6 +8,12 @@
         "screenshot": "https://raw.githubusercontent.com/Pearapps/InitializeMe/master/Phoenix/Phoenix.png"
     },
     {
+        "name": "ThinStrokes",
+        "url": "https://github.com/liscio/ThinStrokes",
+        "description": "Use a light-on-dark color scheme in Xcode, and frustrated by Xcode's too-heavy font rendering? Get sharper text using ThinStrokes!",
+        "screenshot": "http://raw.github.com/liscio/ThinStrokes/master/ThinStrokes@2x.png"
+    },
+    {
         "name": "StringManage",
         "url": "https://github.com/Loongwoo/StringManage",
         "description": "Manage all the strings in localizable.strings, including adding,removing,searching and checking whether it used or not.",


### PR DESCRIPTION
I threw together a solution to a long-frustrating problem I had with Xcode & light-on-dark fonts: https://github.com/liscio/ThinStrokes.

`rspec` passed, and I have a release tag + binary up as well. Let me know if I missed anything!