### PR TITLE
add ImportSorter

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2059,6 +2059,12 @@
         "screenshot": "https://raw.githubusercontent.com/freesuraj/SwiftTemplate/master/Screenshot.png"
       },
       {
+        "name": "ImportSorter",
+        "url": "https://github.com/manji602/ImportSorter",
+        "description": "Sorting import declarations for Xcode",
+        "screenshot": "https://cloud.githubusercontent.com/assets/531477/12872322/e7b4f520-cde3-11e5-8814-8337b7aeb781.png"
+      },
+      {
         "name": "DRL-Theme-Manager",
         "url": "https://github.com/durul/DRL-Theme-Manager.git",
         "description": "Xcode template to generate swift theme manager.",

--- a/packages.json
+++ b/packages.json
@@ -8,6 +8,12 @@
         "screenshot": "https://raw.githubusercontent.com/Pearapps/InitializeMe/master/Phoenix/Phoenix.png"
     },
     {
+        "name": "ImportSorter",
+        "url": "https://github.com/manji602/ImportSorter",
+        "description": "Sorting import declarations for Xcode",
+        "screenshot": "https://cloud.githubusercontent.com/assets/531477/12872322/e7b4f520-cde3-11e5-8814-8337b7aeb781.png"
+    },
+    {
         "name": "ThinStrokes",
         "url": "https://github.com/liscio/ThinStrokes",
         "description": "Use a light-on-dark color scheme in Xcode, and frustrated by Xcode's too-heavy font rendering? Get sharper text using ThinStrokes!",
@@ -2057,12 +2063,6 @@
         "url": "https://github.com/freesuraj/SwiftTemplate",
         "description": "Generates swift templates using MVVM (model view view model) design pattern",
         "screenshot": "https://raw.githubusercontent.com/freesuraj/SwiftTemplate/master/Screenshot.png"
-      },
-      {
-        "name": "ImportSorter",
-        "url": "https://github.com/manji602/ImportSorter",
-        "description": "Sorting import declarations for Xcode",
-        "screenshot": "https://cloud.githubusercontent.com/assets/531477/12872322/e7b4f520-cde3-11e5-8814-8337b7aeb781.png"
       },
       {
         "name": "DRL-Theme-Manager",


### PR DESCRIPTION
I want to add my plugin( https://github.com/manji602/ImportSorter ) onto alcatraz.
This plugin enables to sort import declarations on Xcode, like show in below:

![image](https://cloud.githubusercontent.com/assets/531477/12872322/e7b4f520-cde3-11e5-8814-8337b7aeb781.png)