### PR TITLE
add RTTinyPNGWebAPIPlugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -379,6 +379,12 @@
         "screenshot": "https://github.com/rickytan/RTImageAssets/raw/master/ScreenCap/usage.gif"
       },
       {
+        "name": "RTTinyPNGWebAPIPlugin",
+        "url": "https://github.com/rickytan/RTTinyPNGWebAPIPlugin",
+        "description": "A Xcode plugin which calls http://tinypng.com api to minimize image assets",
+        "screenshot": "https://github.com/rickytan/RTTinyPNGWebAPIPlugin/raw/master/ScreenShots/s0.png"
+      },
+      {
         "name": "SCXcodeMinimap",
         "url": "https://github.com/stefanceriu/SCXcodeMiniMap",
         "description": "SCXcodeMiniMap is a plugin that adds a source editor MiniMap to Xcode."


### PR DESCRIPTION
A Xcode plugin which calls http://tinypng.com api to minimize image assets