### PR TITLE
Updates Swiftr thumbnail to better fit the package manager's layout

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -927,7 +927,7 @@
         "name": "XCSwiftr",
         "url": "https://github.com/dzenbot/XCSwiftr",
         "description": "An Xcode Plugin to convert Objective-C to Swift.",
-        "screenshot": "https://raw.githubusercontent.com/dzenbot/XCSwiftr/master/Documentation/Screenshots/screenshot_main.png"
+        "screenshot": "https://raw.githubusercontent.com/dzenbot/XCSwiftr/master/Documentation/Screenshots/screenshot_alcatraz.png"
       },
       {
         "name": "SwiftyJSON",


### PR DESCRIPTION
The current screenshot wasn't looking ok.

New screenshot:
![image](https://raw.githubusercontent.com/dzenbot/XCSwiftr/master/Documentation/Screenshots/screenshot_alcatraz.png)