### PR TITLE
Add Plugin RestartSourceKitService

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1525,6 +1525,12 @@
         "url": "https://github.com/pigpigdaddy/LFAutoTarget.git",
         "description": "You setup any target by name, LFAutoTarget select target automaticly for you when you add a new file.",
         "screenshot": "https://github.com/pigpigdaddy/LFAutoTarget/blob/master/LFAutoTarget/screenshot.png"
+      },
+      {
+        "name": "Restart SourceKitService!",
+        "url": "https://github.com/hewigovens/RestartSourceKitService.git",
+        "description": "Add Restart SourceKitService! to Xcode Debug menu",
+        "screenshot": "https://github.com/hewigovens/RestartSourceKitService/blob/master/docs/screenshot.png"
       }
     ],
     "color_schemes": [
@@ -2328,12 +2334,6 @@
         "url": "https://github.com/phranck/Xcode-Coordinator-Template.git",
         "description": "An Xcode File Template that creates an Objective-C Coordinator class. It is for both iOS and OS X.",
         "screenshot": "https://github.com/phranck/Xcode-Coordinator-Template/blob/master/img/xcode-coordinator-install.png"
-      },
-      {
-        "name": "Restart SourceKitService!",
-        "url": "https://github.com/hewigovens/RestartSourceKitService.git",
-        "description": "Add Restart SourceKitService! to Xcode Debug menu",
-        "screenshot": "https://github.com/hewigovens/RestartSourceKitService/blob/master/docs/screenshot.png"
       }
     ]
   }

--- a/packages.json
+++ b/packages.json
@@ -2328,6 +2328,12 @@
         "url": "https://github.com/phranck/Xcode-Coordinator-Template.git",
         "description": "An Xcode File Template that creates an Objective-C Coordinator class. It is for both iOS and OS X.",
         "screenshot": "https://github.com/phranck/Xcode-Coordinator-Template/blob/master/img/xcode-coordinator-install.png"
+      },
+      {
+        "name": "Restart SourceKitService!",
+        "url": "https://github.com/hewigovens/RestartSourceKitService.git",
+        "description": "Add Restart SourceKitService! to Xcode Debug menu",
+        "screenshot": "https://github.com/hewigovens/RestartSourceKitService/blob/master/docs/screenshot.png"
       }
     ]
   }


### PR DESCRIPTION
Add "Restart RestartSourceKitService!" to Xcode Debug menu. Sometimes highlighting for Swift is not working and can't be recovered itself...