### PR TITLE
Update Solarized Dark for Xcode link and description

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1966,8 +1966,8 @@
       },
       {
         "name": "Solarized Dark for Xcode",
-        "url": "https://raw.githubusercontent.com/ArtSabintsev/Solarized-Dark-for-Xcode/master/Solarized%20Dark%20@ArtSabintsev.dvtcolortheme",
-        "description": "Solarized Dark Theme for Xcode 5.",
+        "url": "https://raw.githubusercontent.com/ArtSabintsev/Solarized-Dark-for-Xcode/master/Solarized_Dark_by_ArtSabintsev.dvtcolortheme",
+        "description": "Solarized Dark Theme for Xcode 5, 6 and 7.",
         "screenshot": "https://raw.githubusercontent.com/ArtSabintsev/Solarized-Dark-for-Xcode/master/solarizedDark.png"
       },
       {


### PR DESCRIPTION
Updating the link as it's no longer working.
The original link with the spaces (%20) has been changed to underscore (_).