### PR TITLE
Add iTimeTrack plugin take 2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1585,6 +1585,12 @@
         "url": "https://github.com/niehaili/Translate",
         "description": "Translate the selected text into Chinese through the keyboard shortcuts shift+command+t ",
         "screenshot": "https://raw.githubusercontent.com/niehaili/Translate/master/snapshot.png"
+      },
+      {
+        "name": "iTimeTrack",
+        "url": "https://github.com/itimetrack/itimetrack-xcode",
+        "description": "iTimeTrack.com automagical billable time generation while you work",
+        "screenshot": "https://raw.githubusercontent.com/itimetrack/itimetrack-xcode/master/itimetrack-screenshot.png"
       }
     ],
     "color_schemes": [


### PR DESCRIPTION
Adding package iTimeTrack, which is a fork of wakatime but logs heartbeats to the itimetrack.com website and automatically generates billable time entries.