### PR TITLE
Remove plugin BTGisterPost-Xcode5

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -458,11 +458,6 @@
         "screenshot": "https://raw.github.com/tyeen/BlockJump/master/screen_record.gif"
       },
       {
-        "name": "BTGisterPost-Xcode5",
-        "url": "https://github.com/LogikBlitz/BTGisterPost_Xcode5",
-        "description": "Xcode 5+ only. This plug-in allow developers to quickly post gist's to GitHub directly from XCode.It supports Xcode 5.x."
-      },
-      {
         "name": "BuildTimeAnalyzer",
         "url": "https://github.com/RobertGummesson/BuildTimeAnalyzer-for-Xcode",
         "description": "Keeps track of where the compiler spends the most time while compiling Swift code.",


### PR DESCRIPTION
The plugin depends on Cocoapods, so installation is guaranteed to fail.
Moreover, the plugin hasn't been updated since 2014, and is only compatible with Xcode 5.

Full build log: https://gist.github.com/guillaume-algis/35b8df1dc49cb7f1480cfe2294a18e43